### PR TITLE
use `useCallback` instead of `useMemo`

### DIFF
--- a/packages/zact/client.ts
+++ b/packages/zact/client.ts
@@ -2,7 +2,7 @@
 
 import type z from "zod";
 import type { ZactAction } from "./server";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 export function useZact<
   InputType extends z.ZodTypeAny,
@@ -15,23 +15,20 @@ export function useZact<
   const [isRunning, setIsLoading] = useState(false);
   const [err, setErr] = useState<Error | null>(null);
 
-  const mutate = useMemo(
-    () => async (input: z.infer<InputType>) => {
-      setIsLoading(true);
-      setErr(null);
-      setData(null);
-      try {
-        const result = await doAction.current(input);
-        setData(result);
-        setIsLoading(false);
-      } catch (e) {
-        console.log(e);
-        setErr(e as Error);
-        setIsLoading(false);
-      }
-    },
-    []
-  );
+  const mutate = useCallback(async (input: z.infer<InputType>) => {
+    setIsLoading(true);
+    setErr(null);
+    setData(null);
+    try {
+      const result = await doAction.current(input);
+      setData(result);
+      setIsLoading(false);
+    } catch (e) {
+      console.log(e);
+      setErr(e as Error);
+      setIsLoading(false);
+    }
+  }, []);
 
   return {
     mutate,


### PR DESCRIPTION
Since `mutate` is a function, the proper hook to be used is `useCallback`.