### PR TITLE
Fix brand name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zact - Zod Server ACTions
 
-We like NextJS Server Actions. We wanted to love them. This package makes them validated and typesafe, so you can use them in things that aren't forms.
+We like Next.js Server Actions. We wanted to love them. This package makes them validated and typesafe, so you can use them in things that aren't forms.
 
 `npm install zact`
 


### PR DESCRIPTION
First of all, thanks so much for zact! Looks like a cool pattern for validation and type safety in Server Actions.

Just a quick PR to fix the brand name of Next.js to the canonical, common form.