### PR TITLE
Show error in client hook example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ import { validatedAction } from "./action";
 import { useZact } from "zact/client";
 
 export const zactTestComponent = () => {
-  const { mutate, data, isRunning } = useZact(validatedAction);
+  const { mutate, data, isRunning, error } = useZact(validatedAction);
 
   return (
     <div>
-      <button onClick={() => mutate({ stuff: "testtestaet" })}>
+      <button onClick={() => mutate({ stuff: "test" })}>
         Run server action
       </button>
       {isRunning && <div>Loading...</div>}
+      {error?.message}
       {data?.message}
     </div>
   );


### PR DESCRIPTION
Just a quick fix, to show that the 'useZact' hook also returns the error, like here: 

https://github.com/pingdotgg/zact/blob/main/examples/appdir/src/app/t3test.tsx