### PR TITLE
use `result.data` when a validator is passed

### DIFF
--- a/packages/zact/server.ts
+++ b/packages/zact/server.ts
@@ -22,13 +22,13 @@ export function zact<InputType extends z.ZodTypeAny>(validator?: InputType) {
     // The wrapper that actually validates
     const validatedAction = async (input: z.infer<InputType>) => {
       if (validator) {
-        // This will throw if the input is invalid
         const result = validator.safeParse(input);
 
         if (!result.success) {
           const validatedError = fromZodError(result.error);
           throw validatedError;
         }
+        return await action(result.data);
       }
       return await action(input);
     };


### PR DESCRIPTION
Currently the validator passed to `zact` is used to parse the input, but the result of the parsing is ignored and the original input is passed anyways. This prevents any transforms from actually taking place, despite the types believing they have. 
This is particularly problematic when using server actions attached to a `form`, as packages like `zod-form-data` don't show any type errors despite being completely broken in runtime.